### PR TITLE
simplify program_id_from_entry()

### DIFF
--- a/idl_utils.py
+++ b/idl_utils.py
@@ -65,14 +65,7 @@ def program_id_from_entry(func) -> bytes | None:
     Try to recover the hard-coded 32-byte program ID in an Anchor entrypoint.
     Returns raw bytes or None if nothing matched.
     """
-    offs = collect_load_cmps(None, func)
-    if len(offs) == 4:
-        raw = (offs[0].to_bytes(8, "little") +
-               offs[8].to_bytes(8, "little") +
-               offs[16].to_bytes(8, "little") +
-               offs[24].to_bytes(8, "little"))
-        return raw
-    return None
+    return collect_load_cmps(None, func)
 
 # were sure to have an entry func, and we find the id in the first memcmp
 def find_entry_memcmp_second_arg(bv, func):


### PR DESCRIPTION
### Description

It seem like `program_id_from_entry` trying to reassemble 32bytes key despite having it already done at `collect_load_cmps`.

### Summary
- Simplified `program_id_from_entry` to return the helper result directly instead of attempting to reassemble the key a second time.
